### PR TITLE
Get collection helper

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -21,6 +21,13 @@ var db = monk('localhost/test');
 var users = wrap(db.get('users'));
 ```
 
+  You can also use the shortcut to create them in one go:
+
+```js
+var wrap = require('co-monk');
+var users = wrap.getCollection('localhost/test', 'users');
+```
+
 ## Example
 
   Simple example:
@@ -56,6 +63,21 @@ res.name.should.equal('Tobi');
 var res = yield users.find({ species: 'ferret' });
 res.should.have.length(3);
 ```
+
+
+  Note; in order to run these examples you need someone to handle the yields, someone like [co](https://github.com/visionmedia/co) or [KoaJs](http://koajs.com/).
+  A full, simple example looks like this
+
+```js
+var co = require('co');
+var users = require('co-monk')
+	.getCollection('localhost/test', 'users');
+
+co(function *(){
+	yield users.insert({ name: 'Tobi', species: 'ferret' })
+	console.log("BAM! User inserted - 2 ");
+})();
+  ```
 
 # License
 

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
  */
 
 var thunkify = require('thunkify');
+var helpers = require('./lib/helpers.js');
 
 /**
  * Methods to wrap.
@@ -37,3 +38,23 @@ module.exports = function(col){
 
   return col;
 };
+
+/**
+ * Creates generator friendly collection
+ *
+ * @param {connectionString} connection string to mongodb
+ * @param {collectionName} the name of the collection to return
+ * @return {Collection}
+ * @api public
+ */
+
+module.exports.getCollection = helpers.getCoMonkCollection;
+
+/**
+ * Creates an monk database from the connectionstring
+ *
+ * @param {connectionString} connection string to mongodb
+ * @return {database} a monk database object
+ * @api public
+ */
+module.exports.getMonkDb = helpers.getDatabase;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,0 +1,30 @@
+/**
+ * Module dependencies.
+ */
+var monk = require('monk');
+
+/**
+ * Creates an monk database from the connectionstring
+ *
+ * @param {connectionString} connection string to mongodb
+ * @return {database} a monk database object
+ * @api public
+ */
+var getDatabase = function (connectionString){
+	return monk(connectionString);
+};
+module.exports.getDatabase = getDatabase;
+
+/**
+ * Creates generator friendly collection
+ *
+ * @param {connectionString} connection string to mongodb
+ * @param {collectionName} the name of the collection to return
+ * @return {Collection}
+ * @api public
+ */
+var getCoMonkCollection = function (connectionString, collectionName) {
+	var db = getDatabase(connectionString);
+	return require('..')(db.get(collectionName));
+};
+module.exports.getCoMonkCollection = getCoMonkCollection;

--- a/test/index.js
+++ b/test/index.js
@@ -3,12 +3,9 @@
  * Module dependencies.
  */
 
-var monk = require('monk');
-var wrap = require('..');
 var co = require('co');
-var db = monk('localhost/test');
-
-var users = wrap(db.get('users'));
+var coMonk = require('..');
+var users = coMonk.getCollection('localhost/test', 'users')
 
 describe('queries', function(){
   it('should work', function(done){
@@ -28,5 +25,19 @@ describe('queries', function(){
       res.should.have.length(3);
 
     })(done);
+  })
+})
+
+describe('helpers', function () {
+  it('provides easy access to monk databases', function (done) {
+    var monkdb = coMonk.getMonkDb('localhost/test');
+    monkdb.should.not.be.null;
+    done();
+  })
+
+  it('provides easy access to collections in one line', function (done) {
+    var us = coMonk.getCollection('localhost/test', 'users');
+    us.should.not.be.null;
+    done();
   })
 })


### PR DESCRIPTION
I grew tired writing the same four lines over and over again, so I started to implement a little helper function in my projects. After a while I thought that it might be a nice addition to the co-monk project itself. 

So instead of doing

``` js
var monk = require('monk');
var wrap = require('co-monk');
var db = monk('localhost/test');
var users = wrap(db.get('users'));
```

you can now just go

``` js
var users = require('co-monk').getCollection('localhost/test', 'users');
```

which is a bit nicer I think. 

Preferably I wanted to create an overload constructor, eliminating the need for the `.getCollection()` function call, but my Node knowledge failed me. Especially with the funky "looping over methods and thunkify them" thing that was going on. 

If you think that would be better, please give me some pointers and I'll try to fix it up. 

I was starting to think if monk itself now can be hidden by this project. Are you only using the helper method there's not use for the database. I have created a method to return the monk database too, btw. But for the client using co-monk you should not need to use monk. 

I have also updated the README to reflect the changes. 

HTH
